### PR TITLE
jsonEncode now preserves float type when decoding float with zero fraction.

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -360,7 +360,10 @@ function jsonEncode(array $data): string
     try
     {
         /** @var string $result */
-        $result = \json_encode($data, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR);
+        $result = \json_encode(
+            $data,
+            \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION
+        );
 
         return $result;
     }

--- a/tests/JsonWrapperTest.php
+++ b/tests/JsonWrapperTest.php
@@ -51,6 +51,14 @@ final class JsonWrapperTest extends TestCase
     /**
      * @test
      */
+    public function preserveZeroFractionWhenEncodeFloat(): void
+    {
+        static::assertSame('{"foo":10.0}', jsonEncode(['foo' => 10.0]));
+    }
+
+    /**
+     * @test
+     */
     public function encodeWithWrongCharset(): void
     {
         $this->expectException(JsonSerializationFailed::class);


### PR DESCRIPTION
If jsonEncode takes json with floating point number result will be int. There is an issue when strict types are used, specifically when float is typehinted.